### PR TITLE
Removed Binance from FAQ

### DIFF
--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -86,7 +86,6 @@ export default function Faq() {
                     <ol>
                         <li>Dex.ag</li>
                         <li>Uniswap</li>
-                        <li>Binance</li>
                         <li>OkEx</li>
                         <li>Bitfinex</li>
                     </ol>


### PR DESCRIPTION
Binance is currently listed as an exchange where you buy DAI, but you can't buy DAI on Binance 🙃